### PR TITLE
Update Cocoapod Package Name and License Company

### DIFF
--- a/CameraKit-iOS.podspec
+++ b/CameraKit-iOS.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   #  summary should be tweet-length, and the description more in depth.
   #
 
-  s.name         = "CameraKit"
+  s.name         = "CameraKit-iOS"
   s.version      = "1.0.0"
   s.summary      = "Camera library for iOS written in pure Swift."
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 CameraKit
+Copyright (c) 2018 Alterac, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ pod init
 Then open the `Podfile` file in your project and add this line to your app target:
 
 ```ruby
-pod CameraKit
+pod CameraKit-iOS
 ```
 
 and it will automatically create a `Podfile` and integrate the pods into the project by creating a separate `.xcworkspace` file. You will open this file in Xcode from now on.


### PR DESCRIPTION
Temporary package name of `CameraKit-iOS` until base `CameraKit` can be claimed.